### PR TITLE
T52885 : MOIN-347 - Issue 20

### DIFF
--- a/src/app/code/community/MageOne/Qps/Model/Http/Client/Curl.php
+++ b/src/app/code/community/MageOne/Qps/Model/Http/Client/Curl.php
@@ -1,6 +1,6 @@
 <?php
 
-class MageOne_Qps_Model_HTTP_Client_Curl extends Mage_HTTP_Client_Curl
+class Mageone_Qps_Model_Http_Client_Curl extends Mage_HTTP_Client_Curl
 {
     /**
      * Parse headers - CURL callback functin


### PR DESCRIPTION
 - fixes class name casing for Mageone_Qps_Model_Http_Client_Curl